### PR TITLE
org-mu4e: move mu4e requirement inside org-mu4e-open

### DIFF
--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -38,7 +38,6 @@
 (require 'org-exp nil 'noerror)
 
 (eval-when-compile (require 'cl))
-(require 'mu4e)
 
 (defgroup org-mu4e nil
   "Settings for the org-mode related functionality in mu4e."
@@ -129,6 +128,7 @@ Example usage:
 (defun org-mu4e-open (path)
   "Open the mu4e message (for paths starting with 'msgid:') or run
 the query (for paths starting with 'query:')."
+  (require 'mu4e)
   (cond
     ((string-match "^msgid:\\(.+\\)" path)
       (mu4e-view-message-with-message-id (match-string 1 path)))


### PR DESCRIPTION
This allows to defer loading mu4e. That is, if we simply put in our
init file:

```emacs-lisp
(with-eval-after-load 'org
  (require 'org-mu4e))
```

then mu4e is only loaded if either we follow a mu4e link from an org
buffer or we call the autoloaded function `mu4e` to read our emails.

Storing org-mode links from mu4e buffers is unaffected by this change
since `org-mu4e-store-link` only applies from mu4e buffers.

Regarding the second, experimental part of org-mu4e.el about editing
mails with org-mode, I am not completely sure but I think it should
also be unaffected since it also seems to only apply from mu4e buffers.